### PR TITLE
Rename to django-model-publisher-ai

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,30 +1,20 @@
-=============================
-django-model-publisher
-=============================
-
-
-.. image:: https://img.shields.io/pypi/v/django-model-publisher.svg
-    :target: https://pypi.python.org/pypi/django-model-publisher
-
-.. image:: https://img.shields.io/pypi/dm/django-model-publisher.svg
-    :target: https://pypi.python.org/pypi/django-model-publisher
-
-.. image:: https://img.shields.io/travis/jp74/django-model-publisher.svg
-    :target: https://travis-ci.org/jp74/django-model-publisher
-
-.. image:: https://coveralls.io/repos/jp74/django-model-publisher/badge.svg?branch=master
-    :target: https://coveralls.io/r/jp74/django-model-publisher?branch=master
+=========================
+Django Model Publisher AI
+=========================
 
 Django model mixins and utilities for a standard publisher workflow.
 
-``django-model-publisher`` supports `Django`_ 1.8 through 1.11 (latest bugfix
+This is a fork of `django-model-publisher
+<https://github.com/jp74/django-model-publisher>`_.
+
+``django-model-publisher-ai`` supports `Django`_ 1.8 through 1.11 (latest bugfix
 release in each series only) on Python 2.7, 3.3 (Django 1.8 only), 3.4, and 3.5.
 
 .. _Django: http://www.djangoproject.com/
 
 This app is available on `PyPI`_.
 
-.. _PyPI: https://pypi.python.org/pypi/django-model-publisher/
+.. _PyPI: https://pypi.python.org/pypi/django-model-publisher-ai/
 
 
 Getting Help
@@ -36,9 +26,9 @@ Documentation for django-model-publisher is available at https://django-model-pu
 Quickstart
 ==========
 
-Install django-model-publisher:
+Install django-model-publisher-ai:
 
-``pip install django-model-publisher``
+``pip install django-model-publisher-ai``
 
 
 Features

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,13 @@ if sys.argv[-1] == 'publish':
 readme = open('README.rst').read()
 
 setup(
-    name='django-model-publisher',
+    name='django-model-publisher-ai',
     version=version,
     description="""Handy mixin/abstract class for providing a "publisher workflow" to arbitrary Django models.""",
     long_description=readme,
     author='JP74',
     author_email='opensource@jp74.com',
-    url='https://github.com/jp74/django-model-publisher',
+    url='https://github.com/andersinno/django-model-publisher-ai',
     packages=[
         'publisher',
     ],


### PR DESCRIPTION
Let's use a different name to publish our fork on PyPI.