### PR TITLE
Remove icon from publish column in admin change list view

### DIFF
--- a/publisher/templates/publisher/change_list_publish.html
+++ b/publisher/templates/publisher/change_list_publish.html
@@ -1,10 +1,6 @@
 {% load i18n %}
 <div class="col-published">
-	<label class="published-icon">
-		<img src="/static/admin/img/icon-yes.gif"{% if not is_published %} style="display:none"{% endif %}>
-		<img src="/static/admin/img/icon-no.gif"{% if is_published %} style="display:none"{% endif %}>
-	</label>
-	{% if has_publish_permission%}
+	{% if has_publish_permission %}
 		<input type="checkbox" class="publish-checkbox" name="status-{{ object.id }}"
 		{% if is_published %} checked{% endif %}
 		value="{{ object.pk}}" data-publish="{{ publish_url }}" data-unpublish="{{ unpublish_url }}"


### PR DESCRIPTION
Remove icons from admin list rows because they made rows to look
more messy.